### PR TITLE
Update zero sigma values at the start of `utils.create_custom_forces`

### DIFF
--- a/grandlig/samplers.py
+++ b/grandlig/samplers.py
@@ -177,12 +177,12 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         # Create the custom forces, if requested (default)
         if createCustomForces:
-            # Get molecule parameters
-            self.mol_params = self.getMoleculeParameters(resname)
             # Create the custom forces
-            (_, self.custom_nb_force) = utils.create_custom_forces(
+            param_dict, self.custom_nb_force = utils.create_custom_forces(
                 system, topology, [resname]
             )
+            # Get molecule parameters
+            self.mol_params = param_dict[resname]
             # Also need to assign exception IDs to each molecule ID
             self.getMoleculeExceptions()
         else:
@@ -301,36 +301,6 @@ class BaseGrandCanonicalMonteCarloSampler(object):
                 self.tracked_variables[key] = 0
 
         return None
-
-    def getMoleculeParameters(self, resname):
-        """
-        Get the non-bonded parameters for each of the atoms in the molecule model used
-
-        Parameters
-        ----------
-        resname : str
-            Name of the molecule residues
-
-        Returns
-        -------
-        mol_params : list
-            List of dictionaries containing the charge, sigma and epsilon for each molecule atom
-        """
-        mol_params = []  # Store parameters in a list
-        for residue in self.topology.residues():
-            if residue.name == resname:
-                for atom in residue.atoms():
-                    # Store the parameters of each atom
-                    atom_params = self.nonbonded_force.getParticleParameters(atom.index)
-                    mol_params.append(
-                        {
-                            "charge": atom_params[0],
-                            "sigma": atom_params[1],
-                            "epsilon": atom_params[2],
-                        }
-                    )
-                break  # Don't need to continue past the first instance
-        return mol_params
 
     def getMoleculeResids(self, resname):
         """

--- a/grandlig/utils.py
+++ b/grandlig/utils.py
@@ -609,6 +609,13 @@ def create_custom_forces(system, topology, resnames):
         if force.__class__.__name__ == "NonbondedForce":
             nonbonded_force = force
 
+    # Make sure that sigma is not equal to zero to avoid division by zero in the soft-core potential calculations
+    for atom_idx in range(nonbonded_force.getNumParticles()):
+        [charge, sigma, epsilon] = nonbonded_force.getParticleParameters(atom_idx)
+        if np.isclose(sigma._value, 0.0):
+            sigma = 1.0 * unit.angstrom
+            nonbonded_force.setParticleParameters(atom_idx, charge, sigma, epsilon)
+
     # Get the parameters corresponding to each molecule type
     param_dict = {}
     for resname in resnames:
@@ -684,10 +691,6 @@ def create_custom_forces(system, topology, resnames):
         # Get atom parameters
         [charge, sigma, epsilon] = nonbonded_force.getParticleParameters(atom_idx)
 
-        # Make sure that sigma is not equal to zero (sometimes an issue with the reference force, this fixes it.)
-        if np.isclose(sigma._value, 0.0):
-            sigma = 1.0 * unit.angstrom
-
         # Add particle to the custom force (with lambda=1 for now)
         custom_sterics.addParticle([sigma, epsilon, 1.0])
         # Dont get rid of the interactions in the original force yet, because we need that information for the exceptions below
@@ -748,10 +751,6 @@ def create_custom_forces(system, topology, resnames):
             exception_idx
         )
 
-        # Make sure that sigma is not equal to zero
-        if np.isclose(sigma._value, 0.0):
-            sigma = 1.0 * unit.angstrom
-
         # Copy this over as an exclusion so it isn't counted by the CustomNonbonded Force
         custom_sterics.addExclusion(i, j)
 
@@ -759,10 +758,6 @@ def create_custom_forces(system, topology, resnames):
     for atom_idx in range(nonbonded_force.getNumParticles()):
         # Get atom parameters
         [charge, sigma, epsilon] = nonbonded_force.getParticleParameters(atom_idx)
-
-        # Make sure that sigma is not equal to zero
-        if np.isclose(sigma._value, 0.0):
-            sigma = 1.0 * unit.angstrom
 
         # Disable steric interactions in the original force by setting epsilon=0 (keep the charges for PME purposes)
         nonbonded_force.setParticleParameters(atom_idx, charge, sigma, abs(0))


### PR DESCRIPTION
## Description

This pull request resolves [Issue #1](https://github.com/essex-lab/grand-lig/issues/1). The root cause was that molecule parameters were set before zero sigma values were corrected to 1.0 Å. These stale parameters were then used later, leading to a division by zero value during soft-core potential calculations.

### Changes Implemented

1.  **Moved Zero Sigma Correction:** Handling `sigma == 0` has been moved to the very beginning of the `utils.create_custom_forces` function.
2.  **Removed Redundant Checks:** Since sigma values are corrected at the start, the three subsequent checks for `if sigma == 0` were no longer necessary and have been removed for improved code clarity.
3. **Removed `getMoleculeParameters`:** This method is redundant because `utils.create_custom_forces` returns the molecule parameters directly.